### PR TITLE
Add painless method to decrement numbers/letters

### DIFF
--- a/IncrementSelection.py
+++ b/IncrementSelection.py
@@ -7,12 +7,24 @@ class IncrementSelectionCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
         arr = self.view.substr(self.view.sel()[0]).replace(' ', '').split(',')
+        second_digit = self.view.substr(self.view.sel()[1]).replace(' ', '').split(',')
+        start = arr[0]
         if len(arr) == 1:
-            step = 1
+
+            diff = 0
+            if start == '':
+                step = 1
+            elif start[0] in self.digits:
+                diff = int(second_digit[0]) - int(start)
+            elif start[0].lower() in self.letters:
+                diff = self.letterDecode(second_digit[0].lower()) - self.letterDecode(start[0].lower())
+
+            if diff != 0:
+                step = diff
+            else:
+                step = 1
         else:
             step = int(arr[1])
-
-        start = arr[0]
 
         if start == '':
             start = 1
@@ -36,12 +48,13 @@ class IncrementSelectionCommand(sublime_plugin.TextCommand):
         elif start[0] in self.letters:
             start = self.letterDecode(start)
             def gen(counter):
-                return self.letterEncode(start + counter)
+                print((start+counter-1)%26+1)
+                return self.letterEncode((start + counter-1)%26+1)
 
         elif start[0] in self.letters.upper():
             start = self.letterDecode(start.lower())
             def gen(counter):
-                return self.letterEncode(start + counter).upper()
+                return self.letterEncode((start + counter-1)%26+1).upper()
 
         elif start[0] in self.special:
             if start[0] == '#':

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Forked from [yulanggong/IncrementSelection](https://github.com/yulanggong/IncrementSelection)
+
+Plugin can now do both increments and decrements painlessly
+
+Increment follows the difference between the first and second number. If there is no difference, it defaults to 1. See examples for more usage details.
+
 Increment Selection
 ==================
 
@@ -33,7 +39,11 @@ Tips:  `[]` stands for a selection, `|` stands for a caret.
 
 	[1] text [1] text [1] -> 1| text 2| text 3|
 
+	[10] text [9] text [1] -> 10| text 9| text 8|
+
 	[a] text [a] text [a] -> a| text b| text c|
+
+	[a] text [c] text [a] -> a| text c| text e|
 
 	[A] text [A] text [A] -> A| text B| text C|
 
@@ -47,6 +57,7 @@ Tips:  `[]` stands for a selection, `|` stands for a caret.
 
 	[#] line 27 -> 27| line 27
 	[#] line 28 -> 28| line 28
+
 
 
 


### PR DESCRIPTION
Plugin now also looks at difference between the first and second elements in
selection and uses that difference as the step. If no difference is
present, step defaults to 1.

Letters also wrap back to a after z.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yulanggong/incrementselection/5)

<!-- Reviewable:end -->
